### PR TITLE
Fuite mémoire dans heritage.cpp

### DIFF
--- a/code/heritage/heritage.cpp
+++ b/code/heritage/heritage.cpp
@@ -12,6 +12,8 @@ using namespace std;
 
 class Base {
 public:
+	virtual ~Base(){}
+
 	void normalMethod() {
 		cout << "Base.normalMethod() appelée" << endl;
 	}
@@ -66,4 +68,6 @@ int main() {
 	Base b = d;
 	b.normalMethod();
 	b.virtualMethod();
+
+	delete pD;
 }

--- a/code/heritage/heritage.cpp
+++ b/code/heritage/heritage.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 class Base {
 public:
-	virtual ~Base(){}
+	virtual ~Base() {}
 
 	void normalMethod() {
 		cout << "Base.normalMethod() appelée" << endl;


### PR DESCRIPTION
L'objet 'Derived' pointé par 'pD', alloué dynamiquement par un `new`, n'était pas libéré à la fin du bloc, générant ainsi une fuite mémoire.

Ajout d'un destructeur virtuel dans la classe mère 'Base' afin de supprimer le warning généré par l'ajout du `delete`.
