### PR TITLE
Fix for systemc installs not in default directory

### DIFF
--- a/code/additionneur/Makefile
+++ b/code/additionneur/Makefile
@@ -7,9 +7,7 @@ SYSTEMC = $(SYSTEMCROOT)
 TLM = $(TLMROOT)
 
 # guess target os name used by systemc's configure
-ARCH = $(shell $(SYSTEMC)/config/config.guess | \
-        sed -e 's/x86_64-.*-linux-gnu/linux64/' \
-            -e 's/i.86-.*-linux-gnu/linux/')
+ARCH = $(shell uname -m | sed -e 's/x86_64.*/linux64/' -e 's/i.86.*/linux/')
 
 INCLUDES = -I. -I$(SYSTEMC)/include
 


### PR DESCRIPTION
If the systemc archive is extracted in a directory and installed in another (with ./configure prefix='/usr/local/' for example),
the config/config.guess file is not in the SYSTEMCROOT directory so the makefile raises an error.
